### PR TITLE
Fix bibao apk model file access

### DIFF
--- a/android_permission_solution.md
+++ b/android_permission_solution.md
@@ -1,0 +1,207 @@
+# Bibao.apk 访问模型文件权限配置解决方案
+
+## 问题分析
+
+您的Bibao.apk应用在访问 `/data/local/qcguiagent/ark_000007_20250724_8850` 目录中的模型文件时遇到权限问题。这主要涉及以下几个方面：
+
+1. **文件系统权限**：Linux标准权限设置
+2. **SELinux策略**：Android系统的强制访问控制
+3. **应用权限**：APK的运行时权限和清单权限
+
+## 解决方案
+
+### 1. 文件系统权限设置
+
+#### 设置目录和文件权限
+```bash
+# 设置模型目录权限（确保应用可以访问）
+chmod 755 /data/local/qcguiagent
+chmod 755 /data/local/qcguiagent/ark_000007_20250724_8850
+chmod -R 644 /data/local/qcguiagent/ark_000007_20250724_8850/*
+
+# 设置所有者为system（您已经完成）
+chown -R system:system /data/local/qcguiagent/ark_000007_20250724_8850
+
+# 设置Bibao.apk权限
+chmod 644 /vendor/app/qcguiagent/Bibao.apk
+chown system:system /vendor/app/qcguiagent/Bibao.apk
+```
+
+### 2. SELinux策略配置
+
+#### 检查当前SELinux状态
+```bash
+# 检查SELinux状态
+getenforce
+
+# 检查文件SELinux标签
+ls -Z /vendor/app/qcguiagent/Bibao.apk
+ls -Z /data/local/qcguiagent/ark_000007_20250724_8850/
+```
+
+#### 设置正确的SELinux标签
+```bash
+# 为APK设置正确的SELinux上下文
+setenforce 0  # 临时关闭SELinux（仅用于测试）
+
+# 设置APK的SELinux标签
+chcon u:object_r:vendor_app_file:s0 /vendor/app/qcguiagent/Bibao.apk
+
+# 设置模型文件目录的SELinux标签
+chcon -R u:object_r:system_data_file:s0 /data/local/qcguiagent/ark_000007_20250724_8850/
+
+# 或者使用更宽松的标签
+chcon -R u:object_r:shell_data_file:s0 /data/local/qcguiagent/ark_000007_20250724_8850/
+```
+
+### 3. 创建自定义SELinux策略
+
+如果需要永久解决方案，需要创建自定义SELinux策略：
+
+#### 创建策略文件
+```bash
+# 创建策略文件目录
+mkdir -p /system/etc/selinux/
+
+# 创建自定义策略
+cat > /system/etc/selinux/bibao_policy.te << 'EOF'
+# Bibao应用访问模型文件的SELinux策略
+type bibao_app, domain;
+type bibao_data_file, file_type, data_file_type;
+
+# 允许bibao应用读取模型文件
+allow bibao_app bibao_data_file:file { read open getattr };
+allow bibao_app bibao_data_file:dir { read search open getattr };
+
+# 允许访问OpenCL
+allow bibao_app gpu_device:chr_file { read write open ioctl };
+allow bibao_app vendor_file:file { read open getattr execute };
+EOF
+```
+
+### 4. OpenCL权限配置
+
+#### 确保OpenCL设备权限
+```bash
+# 检查OpenCL设备
+ls -la /dev/kgsl-3d0
+ls -la /dev/mali*
+
+# 设置OpenCL设备权限
+chmod 666 /dev/kgsl-3d0  # Qualcomm GPU
+chmod 666 /dev/mali0     # ARM Mali GPU (如果存在)
+
+# 设置OpenCL库权限
+chmod 755 /vendor/lib*/libOpenCL.so
+chmod 755 /system/lib*/libOpenCL.so
+```
+
+### 5. 应用清单权限
+
+确保Bibao.apk的AndroidManifest.xml包含必要权限：
+
+```xml
+<uses-permission android:name="android.permission.READ_EXTERNAL_STORAGE" />
+<uses-permission android:name="android.permission.WRITE_EXTERNAL_STORAGE" />
+<uses-permission android:name="android.permission.ACCESS_NETWORK_STATE" />
+<uses-permission android:name="android.permission.INTERNET" />
+<!-- OpenCL权限 -->
+<uses-permission android:name="android.permission.CAMERA" />
+<uses-feature android:name="android.hardware.opengles.aep" android:required="false" />
+```
+
+## 完整部署脚本
+
+### 部署脚本 (deploy_bibao.sh)
+```bash
+#!/bin/bash
+
+# Bibao.apk完整部署脚本
+
+echo "开始部署Bibao.apk..."
+
+# 1. 创建必要目录
+mkdir -p /vendor/app/qcguiagent
+mkdir -p /data/local/qcguiagent
+
+# 2. 复制APK文件（假设从当前目录）
+cp Bibao.apk /vendor/app/qcguiagent/
+
+# 3. 设置APK权限
+chown system:system /vendor/app/qcguiagent/Bibao.apk
+chmod 644 /vendor/app/qcguiagent/Bibao.apk
+
+# 4. 设置模型文件目录权限
+chown -R system:system /data/local/qcguiagent/ark_000007_20250724_8850
+chmod 755 /data/local/qcguiagent
+chmod 755 /data/local/qcguiagent/ark_000007_20250724_8850
+find /data/local/qcguiagent/ark_000007_20250724_8850 -type f -exec chmod 644 {} \;
+find /data/local/qcguiagent/ark_000007_20250724_8850 -type d -exec chmod 755 {} \;
+
+# 5. 设置SELinux标签
+chcon u:object_r:vendor_app_file:s0 /vendor/app/qcguiagent/Bibao.apk
+chcon -R u:object_r:system_data_file:s0 /data/local/qcguiagent/ark_000007_20250724_8850/
+
+# 6. 设置OpenCL设备权限
+if [ -e /dev/kgsl-3d0 ]; then
+    chmod 666 /dev/kgsl-3d0
+    chown system:system /dev/kgsl-3d0
+fi
+
+if [ -e /dev/mali0 ]; then
+    chmod 666 /dev/mali0
+    chown system:system /dev/mali0
+fi
+
+# 7. 重启相关服务
+stop
+start
+
+echo "Bibao.apk部署完成!"
+echo "请检查应用是否可以正常访问模型文件"
+```
+
+## 故障排除
+
+### 1. 检查日志
+```bash
+# 查看系统日志
+logcat | grep -i bibao
+logcat | grep -i denied
+logcat | grep -i opencl
+
+# 查看SELinux拒绝日志
+dmesg | grep avc
+```
+
+### 2. 测试访问权限
+```bash
+# 测试文件访问权限
+su system -c "ls -la /data/local/qcguiagent/ark_000007_20250724_8850/"
+su system -c "cat /data/local/qcguiagent/ark_000007_20250724_8850/README.txt"  # 如果存在
+```
+
+### 3. 临时解决方案
+如果以上方案不起作用，可以临时使用：
+```bash
+# 临时关闭SELinux（仅用于测试）
+setenforce 0
+
+# 设置更宽松的权限
+chmod -R 777 /data/local/qcguiagent/ark_000007_20250724_8850/
+```
+
+## 注意事项
+
+1. **安全性**：确保权限设置不会影响系统安全
+2. **持久性**：某些权限可能在重启后丢失，需要添加到启动脚本
+3. **兼容性**：不同Android版本的SELinux策略可能有差异
+4. **测试**：在生产环境应用前，请在测试设备上验证所有配置
+
+## 建议的实施步骤
+
+1. 首先应用文件系统权限配置
+2. 测试应用是否可以访问文件
+3. 如果仍有问题，配置SELinux策略
+4. 最后配置OpenCL相关权限
+5. 验证所有功能正常工作

--- a/deploy_bibao.sh
+++ b/deploy_bibao.sh
@@ -1,0 +1,183 @@
+#!/bin/bash
+
+# Bibao.apk完整部署脚本
+# 解决APK访问模型文件权限问题
+
+set -e  # 遇到错误立即退出
+
+echo "========================================="
+echo "开始部署Bibao.apk..."
+echo "========================================="
+
+# 检查是否有root权限
+if [ "$EUID" -ne 0 ]; then 
+    echo "错误: 此脚本需要root权限运行"
+    echo "请使用: sudo bash deploy_bibao.sh"
+    exit 1
+fi
+
+# 1. 创建必要目录
+echo "步骤1: 创建必要目录..."
+mkdir -p /vendor/app/qcguiagent
+mkdir -p /data/local/qcguiagent
+echo "✓ 目录创建完成"
+
+# 2. 复制APK文件（假设从当前目录）
+echo "步骤2: 部署APK文件..."
+if [ -f "Bibao.apk" ]; then
+    cp Bibao.apk /vendor/app/qcguiagent/
+    echo "✓ APK文件复制完成"
+else
+    echo "警告: 当前目录未找到Bibao.apk文件"
+    echo "请确保APK文件位于 /vendor/app/qcguiagent/Bibao.apk"
+fi
+
+# 3. 设置APK权限
+echo "步骤3: 设置APK文件权限..."
+if [ -f "/vendor/app/qcguiagent/Bibao.apk" ]; then
+    chown system:system /vendor/app/qcguiagent/Bibao.apk
+    chmod 644 /vendor/app/qcguiagent/Bibao.apk
+    echo "✓ APK权限设置完成"
+else
+    echo "错误: 找不到APK文件，跳过权限设置"
+fi
+
+# 4. 设置模型文件目录权限
+echo "步骤4: 设置模型文件目录权限..."
+if [ -d "/data/local/qcguiagent/ark_000007_20250724_8850" ]; then
+    # 设置所有者
+    chown -R system:system /data/local/qcguiagent/ark_000007_20250724_8850
+    
+    # 设置目录权限
+    chmod 755 /data/local/qcguiagent
+    chmod 755 /data/local/qcguiagent/ark_000007_20250724_8850
+    
+    # 递归设置文件和目录权限
+    find /data/local/qcguiagent/ark_000007_20250724_8850 -type f -exec chmod 644 {} \;
+    find /data/local/qcguiagent/ark_000007_20250724_8850 -type d -exec chmod 755 {} \;
+    
+    echo "✓ 模型文件目录权限设置完成"
+else
+    echo "错误: 模型文件目录不存在: /data/local/qcguiagent/ark_000007_20250724_8850"
+    echo "请确保模型文件已正确部署"
+    exit 1
+fi
+
+# 5. 检查并设置SELinux标签
+echo "步骤5: 配置SELinux权限..."
+
+# 检查SELinux状态
+if command -v getenforce >/dev/null 2>&1; then
+    SELINUX_STATUS=$(getenforce)
+    echo "当前SELinux状态: $SELINUX_STATUS"
+    
+    if [ "$SELINUX_STATUS" = "Enforcing" ]; then
+        # 设置APK的SELinux标签
+        if [ -f "/vendor/app/qcguiagent/Bibao.apk" ]; then
+            chcon u:object_r:vendor_app_file:s0 /vendor/app/qcguiagent/Bibao.apk 2>/dev/null || \
+            chcon u:object_r:system_app_data_file:s0 /vendor/app/qcguiagent/Bibao.apk 2>/dev/null || \
+            echo "警告: 无法设置APK的SELinux标签"
+        fi
+        
+        # 设置模型文件目录的SELinux标签
+        chcon -R u:object_r:system_data_file:s0 /data/local/qcguiagent/ark_000007_20250724_8850/ 2>/dev/null || \
+        chcon -R u:object_r:shell_data_file:s0 /data/local/qcguiagent/ark_000007_20250724_8850/ 2>/dev/null || \
+        echo "警告: 无法设置模型文件的SELinux标签"
+        
+        echo "✓ SELinux标签设置完成"
+    fi
+else
+    echo "注意: 系统不支持SELinux或命令不可用"
+fi
+
+# 6. 设置OpenCL设备权限
+echo "步骤6: 配置OpenCL设备权限..."
+
+# Qualcomm GPU设备
+if [ -e /dev/kgsl-3d0 ]; then
+    chmod 666 /dev/kgsl-3d0
+    chown system:system /dev/kgsl-3d0
+    echo "✓ Qualcomm GPU设备权限设置完成"
+fi
+
+# ARM Mali GPU设备
+if [ -e /dev/mali0 ]; then
+    chmod 666 /dev/mali0
+    chown system:system /dev/mali0
+    echo "✓ ARM Mali GPU设备权限设置完成"
+fi
+
+# 其他可能的GPU设备
+for device in /dev/dri/card* /dev/dri/render*; do
+    if [ -e "$device" ]; then
+        chmod 666 "$device"
+        chown system:system "$device"
+        echo "✓ GPU设备权限设置完成: $device"
+    fi
+done
+
+# 设置OpenCL库权限
+for lib in /vendor/lib*/libOpenCL.so /system/lib*/libOpenCL.so; do
+    if [ -f "$lib" ]; then
+        chmod 755 "$lib"
+        echo "✓ OpenCL库权限设置完成: $lib"
+    fi
+done
+
+# 7. 验证权限设置
+echo "步骤7: 验证权限设置..."
+
+echo "APK文件权限:"
+if [ -f "/vendor/app/qcguiagent/Bibao.apk" ]; then
+    ls -la /vendor/app/qcguiagent/Bibao.apk
+    if command -v ls >/dev/null 2>&1 && ls --help 2>&1 | grep -q "\-Z"; then
+        ls -Z /vendor/app/qcguiagent/Bibao.apk 2>/dev/null || echo "无法显示SELinux标签"
+    fi
+fi
+
+echo "模型文件目录权限:"
+ls -la /data/local/qcguiagent/ark_000007_20250724_8850/ | head -10
+
+# 8. 创建权限验证脚本
+echo "步骤8: 创建权限验证脚本..."
+cat > /data/local/qcguiagent/verify_permissions.sh << 'EOF'
+#!/bin/bash
+echo "=== Bibao.apk 权限验证脚本 ==="
+
+echo "1. 检查APK文件:"
+ls -la /vendor/app/qcguiagent/Bibao.apk 2>/dev/null || echo "APK文件不存在"
+
+echo "2. 检查模型文件目录:"
+ls -la /data/local/qcguiagent/ark_000007_20250724_8850/ 2>/dev/null || echo "模型目录不存在"
+
+echo "3. 检查OpenCL设备:"
+for device in /dev/kgsl-3d0 /dev/mali0; do
+    if [ -e "$device" ]; then
+        echo "$device: $(ls -la $device)"
+    fi
+done
+
+echo "4. 测试system用户访问权限:"
+su system -c "ls /data/local/qcguiagent/ark_000007_20250724_8850/" 2>/dev/null && echo "✓ system用户可以访问模型目录" || echo "✗ system用户无法访问模型目录"
+
+echo "=== 验证完成 ==="
+EOF
+
+chmod +x /data/local/qcguiagent/verify_permissions.sh
+echo "✓ 权限验证脚本创建完成: /data/local/qcguiagent/verify_permissions.sh"
+
+echo "========================================="
+echo "Bibao.apk部署完成!"
+echo "========================================="
+
+echo "后续步骤:"
+echo "1. 运行验证脚本: bash /data/local/qcguiagent/verify_permissions.sh"
+echo "2. 如果仍有问题，查看日志: logcat | grep -i 'bibao\\|denied\\|opencl'"
+echo "3. 临时测试可以关闭SELinux: setenforce 0"
+echo "4. 重启设备以确保所有权限生效"
+
+echo ""
+echo "注意事项:"
+echo "- 某些权限可能需要重启后才能完全生效"
+echo "- 如果问题持续，请检查应用的AndroidManifest.xml权限声明"
+echo "- 建议在测试环境先验证配置的正确性"

--- a/troubleshooting_commands.sh
+++ b/troubleshooting_commands.sh
@@ -1,0 +1,122 @@
+#!/bin/bash
+
+# Bibao.apk 故障排除命令集合
+# 用于诊断和解决权限问题
+
+echo "========================================="
+echo "Bibao.apk 故障排除命令"
+echo "========================================="
+
+echo "1. 基本权限检查"
+echo "==================="
+
+echo "检查APK文件："
+ls -la /vendor/app/qcguiagent/Bibao.apk 2>/dev/null || echo "APK文件不存在"
+
+echo "检查APK SELinux标签："
+ls -Z /vendor/app/qcguiagent/Bibao.apk 2>/dev/null || echo "无法获取SELinux标签"
+
+echo "检查模型目录："
+ls -la /data/local/qcguiagent/ark_000007_20250724_8850/ 2>/dev/null || echo "模型目录不存在或无法访问"
+
+echo "检查模型目录SELinux标签："
+ls -Z /data/local/qcguiagent/ark_000007_20250724_8850/ 2>/dev/null || echo "无法获取模型目录SELinux标签"
+
+echo ""
+echo "2. SELinux状态检查"
+echo "==================="
+
+echo "SELinux状态："
+getenforce 2>/dev/null || echo "SELinux命令不可用"
+
+echo "检查SELinux拒绝日志："
+dmesg | grep avc | tail -10 2>/dev/null || echo "无SELinux拒绝日志或无权限查看"
+
+echo ""
+echo "3. OpenCL设备检查"
+echo "==================="
+
+echo "Qualcomm GPU设备："
+ls -la /dev/kgsl-3d0 2>/dev/null || echo "/dev/kgsl-3d0 不存在"
+
+echo "ARM Mali GPU设备："
+ls -la /dev/mali* 2>/dev/null || echo "Mali GPU设备不存在"
+
+echo "DRI设备："
+ls -la /dev/dri/* 2>/dev/null || echo "DRI设备不存在"
+
+echo "OpenCL库："
+find /vendor /system -name "*OpenCL*" -type f 2>/dev/null || echo "未找到OpenCL库"
+
+echo ""
+echo "4. 系统日志检查"
+echo "==================="
+
+echo "最近的Bibao相关日志："
+logcat -d | grep -i bibao | tail -10 2>/dev/null || echo "无Bibao相关日志或logcat不可用"
+
+echo "最近的权限拒绝日志："
+logcat -d | grep -i denied | tail -10 2>/dev/null || echo "无权限拒绝日志"
+
+echo "最近的OpenCL相关日志："
+logcat -d | grep -i opencl | tail -10 2>/dev/null || echo "无OpenCL相关日志"
+
+echo ""
+echo "5. 用户权限测试"
+echo "==================="
+
+echo "测试system用户访问模型目录："
+su system -c "ls /data/local/qcguiagent/ark_000007_20250724_8850/" 2>/dev/null && echo "✓ system用户可以访问" || echo "✗ system用户无法访问"
+
+echo "测试system用户读取模型文件："
+su system -c "head -c 100 /data/local/qcguiagent/ark_000007_20250724_8850/*" 2>/dev/null && echo "✓ system用户可以读取文件" || echo "✗ system用户无法读取文件"
+
+echo ""
+echo "6. 快速修复命令"
+echo "==================="
+
+cat << 'EOF'
+# 如果上述检查发现问题，可以尝试以下快速修复：
+
+# 修复基本权限：
+sudo chown -R system:system /data/local/qcguiagent/ark_000007_20250724_8850
+sudo chmod 755 /data/local/qcguiagent/ark_000007_20250724_8850
+sudo find /data/local/qcguiagent/ark_000007_20250724_8850 -type f -exec chmod 644 {} \;
+
+# 修复SELinux标签：
+sudo chcon -R u:object_r:system_data_file:s0 /data/local/qcguiagent/ark_000007_20250724_8850/
+
+# 临时关闭SELinux（仅用于测试）：
+sudo setenforce 0
+
+# 修复OpenCL设备权限：
+sudo chmod 666 /dev/kgsl-3d0  # Qualcomm
+sudo chmod 666 /dev/mali0     # ARM Mali
+
+# 更宽松的权限（仅用于测试）：
+sudo chmod -R 777 /data/local/qcguiagent/ark_000007_20250724_8850/
+EOF
+
+echo ""
+echo "7. 应用级检查建议"
+echo "==================="
+
+cat << 'EOF'
+请检查Bibao.apk的AndroidManifest.xml是否包含以下权限：
+
+<uses-permission android:name="android.permission.READ_EXTERNAL_STORAGE" />
+<uses-permission android:name="android.permission.WRITE_EXTERNAL_STORAGE" />
+<uses-permission android:name="android.permission.ACCESS_NETWORK_STATE" />
+<uses-permission android:name="android.permission.INTERNET" />
+
+对于OpenCL使用，可能需要：
+<uses-permission android:name="android.permission.CAMERA" />
+<uses-feature android:name="android.hardware.opengles.aep" android:required="false" />
+
+如果应用运行时还是无法访问，可能需要在应用代码中请求运行时权限。
+EOF
+
+echo ""
+echo "========================================="
+echo "故障排除完成"
+echo "========================================="


### PR DESCRIPTION
Add scripts and documentation to resolve Android application file and OpenCL access permissions.

The Bibao.apk application was encountering errors when trying to access model files located in `/data/local/qcguiagent/ark_000007_20250724_8850` and utilize OpenCL. This PR provides solutions addressing Linux file system permissions, SELinux policies, and OpenCL device access rights.

---
<a href="https://cursor.com/background-agent?bcId=bc-e1de5853-2c05-4102-b96d-68f0b26715f5">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-e1de5853-2c05-4102-b96d-68f0b26715f5">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

