### PR TITLE
Add exif location to image

### DIFF
--- a/add_gps_exif.py
+++ b/add_gps_exif.py
@@ -1,0 +1,120 @@
+#!/usr/bin/env python3
+
+"""
+Add GPS EXIF metadata (latitude/longitude, optional altitude) to JPEG/TIFF using piexif.
+
+Usage:
+  python3 add_gps_exif.py --image <path> --lat <decimal> --lon <decimal> [--alt <meters>] [--datetime "YYYY:MM:DD HH:MM:SS"] [--overwrite]
+
+Notes:
+  - Works for JPEG/TIFF. For HEIC/PNG and wider format support, use exiftool (see add_gps_exif.sh).
+  - Install deps: pip install piexif Pillow
+"""
+
+import argparse
+import os
+import sys
+from typing import Optional
+
+import piexif
+from PIL import Image
+
+
+def to_rational(value: float):
+    from fractions import Fraction
+    frac = Fraction(value).limit_denominator(1000000)
+    return (frac.numerator, frac.denominator)
+
+
+def deg_to_dms_rationals(decimal_degrees: float):
+    sign = -1 if decimal_degrees < 0 else 1
+    abs_val = abs(decimal_degrees)
+    degrees = int(abs_val)
+    minutes_full = (abs_val - degrees) * 60.0
+    minutes = int(minutes_full)
+    seconds = (minutes_full - minutes) * 60.0
+    return (
+        to_rational(degrees),
+        to_rational(minutes),
+        to_rational(seconds),
+        sign,
+    )
+
+
+def build_gps_ifd(lat: float, lon: float, alt: Optional[float]):
+    lat_deg, lat_min, lat_sec, lat_sign = deg_to_dms_rationals(lat)
+    lon_deg, lon_min, lon_sec, lon_sign = deg_to_dms_rationals(lon)
+
+    gps_ifd = {
+        piexif.GPSIFD.GPSLatitudeRef: b"S" if lat_sign < 0 else b"N",
+        piexif.GPSIFD.GPSLatitude: [lat_deg, lat_min, lat_sec],
+        piexif.GPSIFD.GPSLongitudeRef: b"W" if lon_sign < 0 else b"E",
+        piexif.GPSIFD.GPSLongitude: [lon_deg, lon_min, lon_sec],
+        piexif.GPSIFD.GPSVersionID: (2, 3, 0, 0),
+    }
+
+    if alt is not None:
+        gps_ifd[piexif.GPSIFD.GPSAltitudeRef] = 1 if alt < 0 else 0
+        gps_ifd[piexif.GPSIFD.GPSAltitude] = to_rational(abs(alt))
+
+    return gps_ifd
+
+
+def main():
+    parser = argparse.ArgumentParser(description="Add GPS EXIF to JPEG/TIFF")
+    parser.add_argument("--image", required=True)
+    parser.add_argument("--lat", type=float, required=True)
+    parser.add_argument("--lon", type=float, required=True)
+    parser.add_argument("--alt", type=float, default=None)
+    parser.add_argument("--datetime", type=str, default=None, help="YYYY:MM:DD HH:MM:SS")
+    parser.add_argument("--overwrite", action="store_true")
+    args = parser.parse_args()
+
+    image_path = args.image
+    if not os.path.isfile(image_path):
+        print(f"Error: image not found: {image_path}", file=sys.stderr)
+        sys.exit(1)
+
+    try:
+        with Image.open(image_path) as img:
+            img.verify()
+    except Exception as exc:
+        print(f"Error: cannot open image or unsupported format: {exc}", file=sys.stderr)
+        sys.exit(1)
+
+    try:
+        exif_dict = {}
+        ifd = build_gps_ifd(args.lat, args.lon, args.alt)
+
+        # Load existing EXIF if present
+        try:
+            exif_dict = piexif.load(image_path)
+        except Exception:
+            exif_dict = {"0th": {}, "Exif": {}, "GPS": {}, "1st": {}, "thumbnail": None}
+
+        exif_dict.setdefault("GPS", {})
+        exif_dict["GPS"].update(ifd)
+
+        if args.datetime:
+            exif_dict.setdefault("Exif", {})
+            exif_dict["Exif"][piexif.ExifIFD.DateTimeOriginal] = args.datetime.encode("ascii")
+
+        exif_bytes = piexif.dump(exif_dict)
+
+        if args.overwrite:
+            piexif.insert(exif_bytes, image_path)
+            output_path = image_path
+        else:
+            root, ext = os.path.splitext(image_path)
+            output_path = f"{root}_gps{ext}"
+            piexif.insert(exif_bytes, image_path, output_path)
+
+        print(f"Wrote GPS EXIF to: {output_path}")
+    except Exception as exc:
+        print(f"Failed to write EXIF: {exc}", file=sys.stderr)
+        sys.exit(1)
+
+
+if __name__ == "__main__":
+    main()
+

--- a/add_gps_exif.sh
+++ b/add_gps_exif.sh
@@ -1,0 +1,125 @@
+#!/usr/bin/env bash
+
+set -euo pipefail
+
+usage() {
+  cat <<EOF
+Add GPS EXIF metadata (latitude/longitude, optional altitude) to an image using exiftool.
+
+Usage:
+  $(basename "$0") --image <path> --lat <decimal> --lon <decimal> [--alt <meters>] [--datetime "YYYY:MM:DD HH:MM:SS"] [--overwrite]
+
+Examples:
+  $(basename "$0") --image photo.jpg --lat 39.9042 --lon 116.4074
+  $(basename "$0") --image IMG_0001.HEIC --lat -33.8688 --lon 151.2093 --alt 58 --overwrite
+
+Notes:
+  - Requires exiftool (macOS: brew install exiftool)
+  - Signed decimals are supported. Use negative latitude for south, negative longitude for west.
+  - Without --overwrite, exiftool will create a backup (filename.jpg_original).
+EOF
+}
+
+if [[ $# -eq 0 ]]; then
+  usage
+  exit 1
+fi
+
+if ! command -v exiftool >/dev/null 2>&1; then
+  echo "Error: exiftool not found. Install via Homebrew: brew install exiftool" >&2
+  exit 1
+fi
+
+IMAGE=""
+LAT=""
+LON=""
+ALT=""
+DATETIME=""
+OVERWRITE=0
+
+while [[ $# -gt 0 ]]; do
+  case "$1" in
+    -i|--image)
+      IMAGE="${2:-}"
+      shift 2
+      ;;
+    --lat)
+      LAT="${2:-}"
+      shift 2
+      ;;
+    --lon)
+      LON="${2:-}"
+      shift 2
+      ;;
+    --alt)
+      ALT="${2:-}"
+      shift 2
+      ;;
+    --datetime)
+      DATETIME="${2:-}"
+      shift 2
+      ;;
+    --overwrite)
+      OVERWRITE=1
+      shift 1
+      ;;
+    -h|--help)
+      usage
+      exit 0
+      ;;
+    *)
+      echo "Unknown argument: $1" >&2
+      usage
+      exit 1
+      ;;
+  esac
+done
+
+if [[ -z "$IMAGE" || -z "$LAT" || -z "$LON" ]]; then
+  echo "Error: --image, --lat and --lon are required." >&2
+  usage
+  exit 1
+fi
+
+if [[ ! -f "$IMAGE" ]]; then
+  echo "Error: image not found: $IMAGE" >&2
+  exit 1
+fi
+
+# Basic numeric validation
+if ! [[ "$LAT" =~ ^-?[0-9]+(\.[0-9]+)?$ ]]; then
+  echo "Error: --lat must be a decimal number." >&2
+  exit 1
+fi
+if ! [[ "$LON" =~ ^-?[0-9]+(\.[0-9]+)?$ ]]; then
+  echo "Error: --lon must be a decimal number." >&2
+  exit 1
+fi
+if [[ -n "$ALT" ]] && ! [[ "$ALT" =~ ^-?[0-9]+(\.[0-9]+)?$ ]]; then
+  echo "Error: --alt must be a decimal number (meters)." >&2
+  exit 1
+fi
+
+EXIFTOOL_FLAGS=(
+  -n
+  "-GPSLatitude=$LAT"
+  "-GPSLongitude=$LON"
+)
+
+if [[ -n "$ALT" ]]; then
+  EXIFTOOL_FLAGS+=("-GPSAltitude=$ALT")
+fi
+
+if [[ -n "$DATETIME" ]]; then
+  EXIFTOOL_FLAGS+=("-DateTimeOriginal=$DATETIME")
+fi
+
+if [[ $OVERWRITE -eq 1 ]]; then
+  EXIFTOOL_FLAGS+=(-overwrite_original)
+fi
+
+exiftool "${EXIFTOOL_FLAGS[@]}" "$IMAGE" | cat
+
+echo "\nDone. Current GPS metadata:"
+exiftool -s -GPS:All "$IMAGE" | cat
+

--- a/add_gps_exif.sh
+++ b/add_gps_exif.sh
@@ -7,16 +7,16 @@ usage() {
 Add GPS EXIF metadata (latitude/longitude, optional altitude) to an image using exiftool.
 
 Usage:
-  $(basename "$0") --image <path> --lat <decimal> --lon <decimal> [--alt <meters>] [--datetime "YYYY:MM:DD HH:MM:SS"] [--overwrite]
+  $(basename "$0") --image <path> --lat <decimal> --lon <decimal> [--alt <meters>] [--datetime "YYYY:MM:DD HH:MM:SS"]
 
 Examples:
   $(basename "$0") --image photo.jpg --lat 39.9042 --lon 116.4074
-  $(basename "$0") --image IMG_0001.HEIC --lat -33.8688 --lon 151.2093 --alt 58 --overwrite
+  $(basename "$0") --image IMG_0001.HEIC --lat -33.8688 --lon 151.2093 --alt 58
 
 Notes:
   - Requires exiftool (macOS: brew install exiftool)
   - Signed decimals are supported. Use negative latitude for south, negative longitude for west.
-  - Without --overwrite, exiftool will create a backup (filename.jpg_original).
+  - Original file is kept unchanged. Output will be written to <name>_output.<ext> in the same directory.
 EOF
 }
 
@@ -86,6 +86,10 @@ if [[ ! -f "$IMAGE" ]]; then
   exit 1
 fi
 
+if [[ $OVERWRITE -eq 1 ]]; then
+  echo "Note: --overwrite is ignored. The script always writes to an _output file." >&2
+fi
+
 # Basic numeric validation
 if ! [[ "$LAT" =~ ^-?[0-9]+(\.[0-9]+)?$ ]]; then
   echo "Error: --lat must be a decimal number." >&2
@@ -114,12 +118,22 @@ if [[ -n "$DATETIME" ]]; then
   EXIFTOOL_FLAGS+=("-DateTimeOriginal=$DATETIME")
 fi
 
-if [[ $OVERWRITE -eq 1 ]]; then
-  EXIFTOOL_FLAGS+=(-overwrite_original)
+# Derive output path: <dir>/<base>_output.<ext>
+DIRNAME=$(dirname -- "$IMAGE")
+BASENAME=$(basename -- "$IMAGE")
+EXT="${BASENAME##*.}"
+NAME_NO_EXT="${BASENAME%.*}"
+
+if [[ "$BASENAME" == "$EXT" ]]; then
+  # No extension
+  OUTPUT_PATH="$DIRNAME/${NAME_NO_EXT}_output"
+else
+  OUTPUT_PATH="$DIRNAME/${NAME_NO_EXT}_output.$EXT"
 fi
 
-exiftool "${EXIFTOOL_FLAGS[@]}" "$IMAGE" | cat
+exiftool "${EXIFTOOL_FLAGS[@]}" -o "$OUTPUT_PATH" "$IMAGE" | cat
 
-echo "\nDone. Current GPS metadata:"
-exiftool -s -GPS:All "$IMAGE" | cat
+echo "\nDone. Output file: $OUTPUT_PATH"
+echo "Current GPS metadata of output:"
+exiftool -s -GPS:All "$OUTPUT_PATH" | cat
 


### PR DESCRIPTION
Add two scripts (`add_gps_exif.sh` and `add_gps_exif.py`) to enable adding GPS EXIF metadata to images, fulfilling the user's request for macOS-compatible solutions.

---
<a href="https://cursor.com/background-agent?bcId=bc-a5b3dbd0-49a7-48aa-9bce-f0bbf1039961">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-a5b3dbd0-49a7-48aa-9bce-f0bbf1039961">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

