### PR TITLE
Summarize travel history into habits

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,0 +1,42 @@
+# Travel Memory Aggregation
+
+This module provides a Kotlin implementation that converts historical travel records (`TravelHistory`) into long-term habits (`TravelHabits`) according to the business rules described in the product requirement:
+
+- Histories are analysed every **14 natural days**.
+- Entries can be merged only when the `userId` and `destination` match, the arrival times fall within the same one-hour window, and the weekday pattern aligns.
+- Arrival times are normalised to the nearest half-hour mark before being written to `TravelHabits`.
+- Weekday patterns collapse automatically:
+  - Monday–Friday ⇒ `工作日`
+  - Saturday–Sunday ⇒ `周末`
+  - Monday–Sunday ⇒ `每天`
+- Aggregated histories are removed from `TravelHistory`.
+- Leftover histories that stay unaggregated for **two cycles (28 days)** are purged.
+
+## Key classes
+
+- `TravelHistory` / `TravelHabits`: Room entities declared under `com.example.travel.data`.
+- `TravelHistoryDao` / `TravelHabitsDao`: DAO contracts the app must implement using Room or any other persistence layer.
+- `TravelMemoryAggregator`: the service that orchestrates each aggregation pass.
+
+## Usage
+
+```kotlin
+val aggregator = TravelMemoryAggregator(
+    historyDao = roomHistoryDao,
+    habitsDao = roomHabitsDao,
+    clock = Clock.systemDefaultZone(),
+    zoneId = ZoneId.of("Asia/Shanghai")
+)
+
+val report = aggregator.aggregateLongTermMemories()
+println("Created habits: ${report.createdHabits.size}")
+```
+
+Call `aggregateLongTermMemories()` once per evaluation window (e.g. via WorkManager). The returned `AggregationReport` details how many histories were analysed, which session IDs were consumed, and how many stale rows were deleted.
+
+## Assumptions & follow-ups
+
+- The travel tag shown to users initially stores the weekday summary, but the UI should still request confirmation/input from the user as described in the requirement.
+- `associatedContacts` is left empty because `TravelHistory` does not carry contact metadata yet. The aggregator exposes a TODO hook to plug in a resolver later.
+- `MIN_OCCURRENCES_FOR_HABIT` is set to 2 to avoid creating a habit from a single trip.
+- The included unit tests (`TravelMemoryAggregatorTest`) use in-memory DAO implementations and can serve as a template for app-side instrumentation tests.

--- a/src/main/kotlin/com/example/travel/data/TravelEntities.kt
+++ b/src/main/kotlin/com/example/travel/data/TravelEntities.kt
@@ -1,0 +1,88 @@
+package com.example.travel.data
+
+import androidx.room.Entity
+import androidx.room.PrimaryKey
+
+/**
+ * A single historical travel record captured on device.
+ */
+@Entity
+data class TravelHistory(
+    /**
+     * Session ID of the trip.
+     */
+    @PrimaryKey
+    var sessionId: Long = 0L,
+
+    /**
+     * When the record was created on device (epoch millis).
+     */
+    var createTime: Long = 0L,
+
+    /**
+     * User identifier.
+     */
+    var userId: Long = 0L,
+
+    /**
+     * Destination name (exact match required).
+     */
+    var destination: String = "",
+
+    /**
+     * Arrival time (epoch millis).
+     */
+    var reachTime: Long = 0L,
+
+    /**
+     * Relationship with the driver, optional.
+     */
+    var relationShip: String = ""
+)
+
+/**
+ * A long-term travel habit distilled from multiple historical trips.
+ */
+@Entity
+data class TravelHabits(
+    /**
+     * Record primary key.
+     */
+    @PrimaryKey(autoGenerate = true)
+    var msgId: Long = 0L,
+
+    /**
+     * When the habit was created (epoch millis).
+     */
+    var createTime: Long = 0L,
+
+    /**
+     * Related user identifier.
+     */
+    var userId: Long = 0L,
+
+    /**
+     * Destination for the habit.
+     */
+    var destination: String = "",
+
+    /**
+     * Representative arrival time (epoch millis, normalized to half hour).
+     */
+    var reachTime: Long = 0L,
+
+    /**
+     * Relationship with the driver, optional.
+     */
+    var relationShip: String = "",
+
+    /**
+     * User confirmed tag, initially empty and filled in by UI later.
+     */
+    var travelTag: String = "",
+
+    /**
+     * Related contacts (comma separated), reserved for future enrichment.
+     */
+    var associatedContacts: String = ""
+)

--- a/src/main/kotlin/com/example/travel/data/dao/TravelDaos.kt
+++ b/src/main/kotlin/com/example/travel/data/dao/TravelDaos.kt
@@ -1,0 +1,35 @@
+package com.example.travel.data.dao
+
+import com.example.travel.data.TravelHabits
+import com.example.travel.data.TravelHistory
+
+/**
+ * DAO abstraction for reading and mutating [TravelHistory] entries.
+ *
+ * The actual implementation can be backed by Room, Realm, or any custom store.
+ */
+interface TravelHistoryDao {
+    /**
+     * Returns all histories created on or before [cutoffEpochMs], ordered however the caller prefers.
+     */
+    suspend fun loadHistoriesBefore(cutoffEpochMs: Long): List<TravelHistory>
+
+    /**
+     * Removes histories with session IDs in [sessionIds].
+     */
+    suspend fun deleteBySessionIds(sessionIds: Collection<Long>)
+
+    /**
+     * Removes histories whose [TravelHistory.createTime] is earlier than [cutoffEpochMs].
+     *
+     * Returns number of deleted rows to help with observability.
+     */
+    suspend fun deleteOlderThan(cutoffEpochMs: Long): Int
+}
+
+/**
+ * DAO abstraction for persisting newly created [TravelHabits].
+ */
+interface TravelHabitsDao {
+    suspend fun insertHabits(habits: Collection<TravelHabits>)
+}

--- a/src/main/kotlin/com/example/travel/service/AggregationResult.kt
+++ b/src/main/kotlin/com/example/travel/service/AggregationResult.kt
@@ -1,0 +1,12 @@
+package com.example.travel.service
+
+import com.example.travel.data.TravelHabits
+
+/**
+ * Encapsulates the habit produced from a cluster of historical trips as well
+ * as the session IDs that were consumed during aggregation.
+ */
+data class AggregationResult(
+    val habit: TravelHabits,
+    val sessionIds: List<Long>
+)

--- a/src/main/kotlin/com/example/travel/service/TravelMemoryAggregator.kt
+++ b/src/main/kotlin/com/example/travel/service/TravelMemoryAggregator.kt
@@ -1,5 +1,6 @@
 package com.example.travel.service
 
+import android.annotation.SuppressLint
 import com.example.travel.data.TravelHabits
 import com.example.travel.data.TravelHistory
 import com.example.travel.data.dao.TravelHabitsDao
@@ -152,7 +153,7 @@ class TravelMemoryAggregator(
             val weekSummary = summarizeWeekdays(cluster)
             val relationShip = pickDominantRelationship(cluster)
 
-            val habitReachEpoch = canonicalInstantFromTime(canonicalTime, now)
+            val habitReachEpoch = canonicalEpochMillisFromTime(canonicalTime, now)
 
             val habit = TravelHabits(
                 createTime = now.toEpochMilli(),
@@ -232,7 +233,19 @@ class TravelMemoryAggregator(
         return counts.maxByOrNull { it.value }?.key.orEmpty()
     }
 
-    private fun canonicalInstantFromTime(time: LocalTime, referenceInstant: Instant): Long {
+    @SuppressLint("NewApi")
+    private fun canonicalInstantFromTime(time: LocalTime, referenceInstant: Instant): String {
+        val hour = time.hour
+        val minute = time.minute
+        val minuteText = minute.toString().padStart(2, '0')
+        return if (hour < 10) {
+            "${hour}:${minuteText}"
+        } else {
+            "$hour:$minuteText"
+        }
+    }
+
+    private fun canonicalEpochMillisFromTime(time: LocalTime, referenceInstant: Instant): Long {
         val referenceDate: LocalDate = referenceInstant.atZone(zoneId).toLocalDate()
         return referenceDate
             .atTime(time)

--- a/src/main/kotlin/com/example/travel/service/TravelMemoryAggregator.kt
+++ b/src/main/kotlin/com/example/travel/service/TravelMemoryAggregator.kt
@@ -236,11 +236,6 @@ class TravelMemoryAggregator(
         val minutesOfDay: Int
     )
 
-    private data class AggregationResult(
-        val habit: TravelHabits,
-        val sessionIds: List<Long>
-    )
-
     data class AggregationReport(
         val createdHabits: List<TravelHabits>,
         val consumedSessionIds: List<Long>,

--- a/src/main/kotlin/com/example/travel/service/TravelMemoryAggregator.kt
+++ b/src/main/kotlin/com/example/travel/service/TravelMemoryAggregator.kt
@@ -19,6 +19,7 @@ import java.time.ZoneId
 import java.util.Locale
 import java.util.UUID
 import kotlin.math.abs
+import kotlin.text.Charsets
 import org.apache.poi.ss.usermodel.DataFormatter
 import org.apache.poi.ss.usermodel.WorkbookFactory
 import org.apache.poi.ss.usermodel.Row
@@ -26,7 +27,7 @@ import org.json.JSONArray
 import org.json.JSONObject
 
 private const val MINUTES_IN_DAY = 24 * 60
-private const val HALF_HOUR_MINUTES = 30
+private const val QUARTER_HOUR_MINUTES = 15
 private const val MAX_TIME_DIFFERENCE_MINUTES = 60
 private const val MIN_OCCURRENCES_FOR_HABIT = 2
 
@@ -193,16 +194,17 @@ class TravelMemoryAggregator(
     }
 
     private fun determineCanonicalTime(cluster: List<HistorySnapshot>): LocalTime {
-        val normalizedCounts = cluster
-            .map { normalizeToNearestHalfHour(it.minutesOfDay) }
-            .groupingBy { it }
-            .eachCount()
-
-        return normalizedCounts.maxByOrNull { it.value }?.key ?: LocalTime.MIDNIGHT
+        val latest = cluster.maxByOrNull { it.minutesOfDay } ?: return LocalTime.MIDNIGHT
+        return normalizeToNearestQuarterHour(latest.minutesOfDay)
     }
 
-    private fun normalizeToNearestHalfHour(minutesOfDay: Int): LocalTime {
-        val roundedMinutes = ((minutesOfDay + HALF_HOUR_MINUTES / 2) / HALF_HOUR_MINUTES) * HALF_HOUR_MINUTES
+    private fun normalizeToNearestQuarterHour(minutesOfDay: Int): LocalTime {
+        val remainder = minutesOfDay % QUARTER_HOUR_MINUTES
+        val roundedMinutes = if (remainder >= (QUARTER_HOUR_MINUTES / 2)) {
+            minutesOfDay + (QUARTER_HOUR_MINUTES - remainder)
+        } else {
+            minutesOfDay - remainder
+        }
         val normalizedMinutes = Math.floorMod(roundedMinutes, MINUTES_IN_DAY)
         return LocalTime.ofSecondOfDay((normalizedMinutes * 60).toLong())
     }
@@ -297,7 +299,9 @@ class TravelMemoryAggregator(
     }
 
     private fun parseJsonFile(path: Path): List<TravelHistory> {
-        val content = Files.readString(path).trim()
+        val bytes = Files.readAllBytes(path)
+        if (bytes.isEmpty()) return emptyList()
+        val content = String(bytes, Charsets.UTF_8).trim()
         if (content.isEmpty()) return emptyList()
 
         val result = mutableListOf<TravelHistory>()

--- a/src/main/kotlin/com/example/travel/service/TravelMemoryAggregator.kt
+++ b/src/main/kotlin/com/example/travel/service/TravelMemoryAggregator.kt
@@ -164,16 +164,17 @@ class TravelMemoryAggregator(
         val sorted = histories.sortedBy { it.minutesOfDay }
         val clusters = mutableListOf<MutableList<HistorySnapshot>>()
         var currentCluster = mutableListOf(sorted.first())
-        var clusterMax = sorted.first().minutesOfDay
+        var clusterMin = sorted.first().minutesOfDay
 
         for (snapshot in sorted.drop(1)) {
-            if (snapshot.minutesOfDay - clusterMax <= MAX_TIME_DIFFERENCE_MINUTES) {
+            val minutes = snapshot.minutesOfDay
+            if (minutes - clusterMin <= MAX_TIME_DIFFERENCE_MINUTES) {
                 currentCluster.add(snapshot)
             } else {
                 clusters.add(currentCluster)
                 currentCluster = mutableListOf(snapshot)
+                clusterMin = minutes
             }
-            clusterMax = snapshot.minutesOfDay
         }
         clusters.add(currentCluster)
         return clusters

--- a/src/main/kotlin/com/example/travel/service/TravelMemoryAggregator.kt
+++ b/src/main/kotlin/com/example/travel/service/TravelMemoryAggregator.kt
@@ -4,6 +4,11 @@ import com.example.travel.data.TravelHabits
 import com.example.travel.data.TravelHistory
 import com.example.travel.data.dao.TravelHabitsDao
 import com.example.travel.data.dao.TravelHistoryDao
+import java.nio.file.Files
+import java.nio.file.Path
+import java.nio.file.Paths
+import java.text.ParseException
+import java.text.SimpleDateFormat
 import java.time.Clock
 import java.time.DayOfWeek
 import java.time.Duration
@@ -12,6 +17,13 @@ import java.time.LocalDate
 import java.time.LocalTime
 import java.time.ZoneId
 import java.util.Locale
+import java.util.UUID
+import kotlin.math.abs
+import org.apache.poi.ss.usermodel.DataFormatter
+import org.apache.poi.ss.usermodel.WorkbookFactory
+import org.apache.poi.ss.usermodel.Row
+import org.json.JSONArray
+import org.json.JSONObject
 
 private const val MINUTES_IN_DAY = 24 * 60
 private const val HALF_HOUR_MINUTES = 30
@@ -243,6 +255,161 @@ class TravelMemoryAggregator(
         val staleHistoryDeleted: Int,
         val analyzedHistoryCount: Int
     )
+
+    /**
+     * 从外部文件导入历史行程记录。
+     */
+    private fun importTripHistory(importFilePath: String): List<TravelHistory> {
+        val path = Paths.get(importFilePath)
+        require(Files.exists(path)) { "Import file not found: $importFilePath" }
+
+        val extension = path.fileName.toString()
+            .substringAfterLast('.', missingDelimiterValue = "")
+            .lowercase(Locale.ROOT)
+
+        return when (extension) {
+            "csv", "txt" -> parseDelimitedFile(path)
+            "json" -> parseJsonFile(path)
+            "xlsx" -> parseXlsxFile(path)
+            else -> parseDelimitedFile(path) // fallback for unknown, treat as text
+        }
+    }
+
+    private fun parseDelimitedFile(path: Path): List<TravelHistory> {
+        if (Files.size(path) == 0L) return emptyList()
+        return Files.newBufferedReader(path).use { reader ->
+            reader.lineSequence()
+                .mapNotNull { parseDelimitedLine(it) }
+                .toList()
+        }
+    }
+
+    private fun parseDelimitedLine(rawLine: String): TravelHistory? {
+        val cleaned = rawLine.trim()
+            .trimStart('[')
+            .trimEnd(']', ',')
+        if (cleaned.isBlank()) return null
+        val pieces = cleaned.split(',')
+            .map { it.trim() }
+            .filter { it.isNotEmpty() }
+
+        return buildHistoryFromFields(pieces)
+    }
+
+    private fun parseJsonFile(path: Path): List<TravelHistory> {
+        val content = Files.readString(path).trim()
+        if (content.isEmpty()) return emptyList()
+
+        val result = mutableListOf<TravelHistory>()
+        when {
+            content.startsWith("[") -> {
+                val array = JSONArray(content)
+                for (i in 0 until array.length()) {
+                    when (val entry = array.get(i)) {
+                        is JSONObject -> buildHistoryFromJson(entry)?.let(result::add)
+                        is JSONArray -> {
+                            val fields = mutableListOf<String>()
+                            for (j in 0 until entry.length()) {
+                                fields += entry.get(j).toString().trim()
+                            }
+                            buildHistoryFromFields(fields)?.let(result::add)
+                        }
+                    }
+                }
+            }
+            content.startsWith("{") -> {
+                buildHistoryFromJson(JSONObject(content))?.let(result::add)
+            }
+        }
+        return result
+    }
+
+    private fun parseXlsxFile(path: Path): List<TravelHistory> {
+        val formatter = DataFormatter()
+        return Files.newInputStream(path).use { input ->
+            WorkbookFactory.create(input).use { workbook ->
+                val histories = mutableListOf<TravelHistory>()
+                for (sheetIndex in 0 until workbook.numberOfSheets) {
+                    val sheet = workbook.getSheetAt(sheetIndex)
+                    for (rowIndex in sheet.firstRowNum..sheet.lastRowNum) {
+                        val row = sheet.getRow(rowIndex) ?: continue
+                        val fields = rowToFields(row, formatter)
+                        buildHistoryFromFields(fields)?.let(histories::add)
+                    }
+                }
+                histories
+            }
+        }
+    }
+
+    private fun rowToFields(row: Row, formatter: DataFormatter): List<String> {
+        val result = mutableListOf<String>()
+        for (cellIndex in 0..3) {
+            val cell = row.getCell(cellIndex) ?: continue
+            val value = formatter.formatCellValue(cell).trim()
+            if (value.isNotEmpty()) {
+                result.add(value)
+            }
+        }
+        return result
+    }
+
+    private fun buildHistoryFromJson(json: JSONObject): TravelHistory? {
+        val fields = listOf(
+            json.optString("userId"),
+            json.optString("destination"),
+            json.optString("reachTime", json.optString("reach_time")),
+            json.optString("relationShip", json.optString("relationship"))
+        )
+        return buildHistoryFromFields(fields)
+    }
+
+    private fun buildHistoryFromFields(fields: List<String>): TravelHistory? {
+        if (fields.size < 3) return null
+        val userId = fields[0].toLongOrNull() ?: return null
+        val destination = fields[1]
+        val reachTime = parseEpochMillis(fields[2]) ?: return null
+        val relationship = fields.getOrNull(3).orEmpty()
+
+        return TravelHistory(
+            sessionId = generateSessionId(),
+            createTime = System.currentTimeMillis(),
+            userId = userId,
+            destination = destination,
+            reachTime = reachTime,
+            relationShip = relationship
+        )
+    }
+
+    private fun parseEpochMillis(raw: String?): Long? {
+        raw ?: return null
+        val normalized = raw.trim()
+        if (normalized.isEmpty()) return null
+
+        val patterns = listOf(
+            "yyyy-MM-dd HH:mm:ss",
+            "yyyy-MM-dd HH:mm",
+            "yyyy/MM/dd HH:mm:ss",
+            "yyyy/MM/dd HH:mm"
+        )
+
+        for (pattern in patterns) {
+            try {
+                val sdf = SimpleDateFormat(pattern, Locale.getDefault())
+                sdf.isLenient = false
+                return sdf.parse(normalized)?.time
+            } catch (_: ParseException) {
+                // try next pattern
+            }
+        }
+        return null
+    }
+
+    private fun generateSessionId(): Long {
+        val uuid = UUID.randomUUID()
+        val candidate = uuid.mostSignificantBits xor uuid.leastSignificantBits
+        return abs(candidate)
+    }
 }
 
 private val weekdayLabels = mapOf(

--- a/src/main/kotlin/com/example/travel/service/TravelMemoryAggregator.kt
+++ b/src/main/kotlin/com/example/travel/service/TravelMemoryAggregator.kt
@@ -1,0 +1,249 @@
+package com.example.travel.service
+
+import com.example.travel.data.TravelHabits
+import com.example.travel.data.TravelHistory
+import com.example.travel.data.dao.TravelHabitsDao
+import com.example.travel.data.dao.TravelHistoryDao
+import java.time.Clock
+import java.time.DayOfWeek
+import java.time.Duration
+import java.time.Instant
+import java.time.LocalDate
+import java.time.LocalTime
+import java.time.ZoneId
+import java.util.Locale
+
+private const val MINUTES_IN_DAY = 24 * 60
+private const val HALF_HOUR_MINUTES = 30
+private const val MAX_TIME_DIFFERENCE_MINUTES = 60
+private const val MIN_OCCURRENCES_FOR_HABIT = 2
+
+private val WORKDAY_SET = setOf(
+    DayOfWeek.MONDAY,
+    DayOfWeek.TUESDAY,
+    DayOfWeek.WEDNESDAY,
+    DayOfWeek.THURSDAY,
+    DayOfWeek.FRIDAY
+)
+
+private val WEEKEND_SET = setOf(
+    DayOfWeek.SATURDAY,
+    DayOfWeek.SUNDAY
+)
+
+/**
+ * Summarises [TravelHistory] rows into [TravelHabits] every 14 natural days.
+ *
+ * The algorithm follows the business rules shared by the product team:
+ * - Histories are collected for a 14-day cycle and turned into habits afterwards.
+ * - Histories can only be merged when user id, destination, day-of-week pattern, and
+ *   arrival time (same 1-hour window) match.
+ * - Arrival times are normalised to the nearest half-hour marker.
+ * - Dates are summarised per weekday. Full work-week => "工作日", weekend => "周末",
+ *   all seven days => "每天".
+ * - Aggregated histories are deleted from the history table; non-aggregated histories
+ *   are kept for at most two cycles (28 days) before being purged.
+ */
+class TravelMemoryAggregator(
+    private val historyDao: TravelHistoryDao,
+    private val habitsDao: TravelHabitsDao,
+    private val clock: Clock = Clock.systemDefaultZone(),
+    private val zoneId: ZoneId = ZoneId.systemDefault()
+    // TODO: inject contact resolver once TravelHistory carries contact metadata.
+) {
+
+    private val cycleLength: Duration = Duration.ofDays(14)
+
+    /**
+     * Performs one aggregation pass and returns a report describing the outcome.
+     */
+    suspend fun aggregateLongTermMemories(nowOverride: Instant? = null): AggregationReport {
+        val now = nowOverride ?: Instant.now(clock)
+        val eligibleCutoff = now.minus(cycleLength).toEpochMilli()
+        val staleCutoff = now.minus(cycleLength.multipliedBy(2)).toEpochMilli()
+
+        val eligibleHistories = historyDao.loadHistoriesBefore(eligibleCutoff)
+
+        if (eligibleHistories.isEmpty()) {
+            val staleRemoved = historyDao.deleteOlderThan(staleCutoff)
+            return AggregationReport(emptyList(), emptyList(), staleRemoved, analyzedHistoryCount = 0)
+        }
+
+        val aggregationResults = eligibleHistories
+            .groupBy { it.userId to it.destination }
+            .flatMap { (key, groupedHistories) ->
+                aggregateGroup(
+                    userId = key.first,
+                    destination = key.second,
+                    histories = groupedHistories,
+                    now = now
+                )
+            }
+
+        val createdHabits = aggregationResults.map { it.habit }
+        val consumedSessionIds = aggregationResults.flatMap { it.sessionIds }
+
+        if (createdHabits.isNotEmpty()) {
+            habitsDao.insertHabits(createdHabits)
+            historyDao.deleteBySessionIds(consumedSessionIds)
+        }
+
+        val staleRemoved = historyDao.deleteOlderThan(staleCutoff)
+
+        return AggregationReport(
+            createdHabits = createdHabits,
+            consumedSessionIds = consumedSessionIds,
+            staleHistoryDeleted = staleRemoved,
+            analyzedHistoryCount = eligibleHistories.size
+        )
+    }
+
+    private fun aggregateGroup(
+        userId: Long,
+        destination: String,
+        histories: List<TravelHistory>,
+        now: Instant
+    ): List<AggregationResult> {
+        val snapshots = histories.map { history ->
+            val reachDateTime = Instant.ofEpochMilli(history.reachTime).atZone(zoneId)
+            HistorySnapshot(
+                sessionId = history.sessionId,
+                userId = userId,
+                destination = destination,
+                reachEpochMs = history.reachTime,
+                relationShip = history.relationShip,
+                dayOfWeek = reachDateTime.dayOfWeek,
+                minutesOfDay = reachDateTime.hour * 60 + reachDateTime.minute
+            )
+        }
+
+        val clusters = clusterByTimeWindow(snapshots)
+
+        return clusters.mapNotNull { cluster ->
+            if (cluster.size < MIN_OCCURRENCES_FOR_HABIT) {
+                return@mapNotNull null
+            }
+
+            val canonicalTime = determineCanonicalTime(cluster)
+            val weekSummary = summarizeWeekdays(cluster)
+            val relationShip = pickDominantRelationship(cluster)
+
+            val habitReachEpoch = canonicalInstantFromTime(canonicalTime, now)
+
+            val habit = TravelHabits(
+                createTime = now.toEpochMilli(),
+                userId = userId,
+                destination = destination,
+                reachTime = habitReachEpoch,
+                relationShip = relationShip,
+                travelTag = weekSummary,
+                associatedContacts = "" // reserved for future use
+            )
+
+            AggregationResult(
+                habit = habit,
+                sessionIds = cluster.map { it.sessionId }
+            )
+        }
+    }
+
+    private fun clusterByTimeWindow(histories: List<HistorySnapshot>): List<List<HistorySnapshot>> {
+        if (histories.isEmpty()) return emptyList()
+
+        val sorted = histories.sortedBy { it.minutesOfDay }
+        val clusters = mutableListOf<MutableList<HistorySnapshot>>()
+        var currentCluster = mutableListOf(sorted.first())
+        var clusterMax = sorted.first().minutesOfDay
+
+        for (snapshot in sorted.drop(1)) {
+            if (snapshot.minutesOfDay - clusterMax <= MAX_TIME_DIFFERENCE_MINUTES) {
+                currentCluster.add(snapshot)
+            } else {
+                clusters.add(currentCluster)
+                currentCluster = mutableListOf(snapshot)
+            }
+            clusterMax = snapshot.minutesOfDay
+        }
+        clusters.add(currentCluster)
+        return clusters
+    }
+
+    private fun determineCanonicalTime(cluster: List<HistorySnapshot>): LocalTime {
+        val normalizedCounts = cluster
+            .map { normalizeToNearestHalfHour(it.minutesOfDay) }
+            .groupingBy { it }
+            .eachCount()
+
+        return normalizedCounts.maxByOrNull { it.value }?.key ?: LocalTime.MIDNIGHT
+    }
+
+    private fun normalizeToNearestHalfHour(minutesOfDay: Int): LocalTime {
+        val roundedMinutes = ((minutesOfDay + HALF_HOUR_MINUTES / 2) / HALF_HOUR_MINUTES) * HALF_HOUR_MINUTES
+        val normalizedMinutes = Math.floorMod(roundedMinutes, MINUTES_IN_DAY)
+        return LocalTime.ofSecondOfDay((normalizedMinutes * 60).toLong())
+    }
+
+    private fun summarizeWeekdays(cluster: List<HistorySnapshot>): String {
+        val daySet = cluster.map { it.dayOfWeek }.toSet()
+        if (daySet.isEmpty()) return ""
+
+        val allDays = DayOfWeek.values().toSet()
+        return when {
+            daySet.containsAll(allDays) -> "每天"
+            daySet.containsAll(WORKDAY_SET) && daySet.subtract(WORKDAY_SET).isEmpty() -> "工作日"
+            daySet.containsAll(WEEKEND_SET) && daySet.subtract(WEEKEND_SET).isEmpty() -> "周末"
+            else -> daySet.sortedBy { it.value }
+                .joinToString(separator = "、") { weekdayLabels[it] ?: it.name.lowercase(Locale.getDefault()) }
+        }
+    }
+
+    private fun pickDominantRelationship(cluster: List<HistorySnapshot>): String {
+        val counts = cluster
+            .mapNotNull { it.relationShip.takeIf(String::isNotBlank) }
+            .groupingBy { it }
+            .eachCount()
+
+        return counts.maxByOrNull { it.value }?.key.orEmpty()
+    }
+
+    private fun canonicalInstantFromTime(time: LocalTime, referenceInstant: Instant): Long {
+        val referenceDate: LocalDate = referenceInstant.atZone(zoneId).toLocalDate()
+        return referenceDate
+            .atTime(time)
+            .atZone(zoneId)
+            .toInstant()
+            .toEpochMilli()
+    }
+
+    private data class HistorySnapshot(
+        val sessionId: Long,
+        val userId: Long,
+        val destination: String,
+        val reachEpochMs: Long,
+        val relationShip: String,
+        val dayOfWeek: DayOfWeek,
+        val minutesOfDay: Int
+    )
+
+    private data class AggregationResult(
+        val habit: TravelHabits,
+        val sessionIds: List<Long>
+    )
+
+    data class AggregationReport(
+        val createdHabits: List<TravelHabits>,
+        val consumedSessionIds: List<Long>,
+        val staleHistoryDeleted: Int,
+        val analyzedHistoryCount: Int
+    )
+}
+
+private val weekdayLabels = mapOf(
+    DayOfWeek.MONDAY to "周一",
+    DayOfWeek.TUESDAY to "周二",
+    DayOfWeek.WEDNESDAY to "周三",
+    DayOfWeek.THURSDAY to "周四",
+    DayOfWeek.FRIDAY to "周五",
+    DayOfWeek.SATURDAY to "周六",
+    DayOfWeek.SUNDAY to "周日"
+)

--- a/src/main/kotlin/com/example/travel/service/TravelMemoryAggregator.kt
+++ b/src/main/kotlin/com/example/travel/service/TravelMemoryAggregator.kt
@@ -53,6 +53,7 @@ class TravelMemoryAggregator(
 ) {
 
     private val cycleLength: Duration = Duration.ofDays(14)
+    private var aggregationReferenceInstant: Instant = Instant.EPOCH
 
     /**
      * Performs one aggregation pass and returns a report describing the outcome.
@@ -69,16 +70,8 @@ class TravelMemoryAggregator(
             return AggregationReport(emptyList(), emptyList(), staleRemoved, analyzedHistoryCount = 0)
         }
 
-        val aggregationResults = eligibleHistories
-            .groupBy { it.userId to it.destination }
-            .flatMap { (key, groupedHistories) ->
-                aggregateGroup(
-                    userId = key.first,
-                    destination = key.second,
-                    histories = groupedHistories,
-                    now = now
-                )
-            }
+        aggregationReferenceInstant = now
+        val aggregationResults = sumUpHistoryRecords(eligibleHistories)
 
         val createdHabits = aggregationResults.map { it.habit }
         val consumedSessionIds = aggregationResults.flatMap { it.sessionIds }
@@ -98,12 +91,30 @@ class TravelMemoryAggregator(
         )
     }
 
+    /**
+     * 归纳历史行程记录列表
+     *
+     * 根据用户 ID、目的地、到达时间（日期 + 时刻）三要素进行聚合，
+     * 生成对应的长期行程记忆。
+     */
+    private fun sumUpHistoryRecords(historyList: List<TravelHistory>): List<AggregationResult> {
+        return historyList
+            .groupBy { it.userId to it.destination }
+            .flatMap { (key, groupedHistories) ->
+                aggregateGroup(
+                    userId = key.first,
+                    destination = key.second,
+                    histories = groupedHistories
+                )
+            }
+    }
+
     private fun aggregateGroup(
         userId: Long,
         destination: String,
-        histories: List<TravelHistory>,
-        now: Instant
+        histories: List<TravelHistory>
     ): List<AggregationResult> {
+        val now = aggregationReferenceInstant
         val snapshots = histories.map { history ->
             val reachDateTime = Instant.ofEpochMilli(history.reachTime).atZone(zoneId)
             HistorySnapshot(

--- a/src/test/kotlin/com/example/travel/service/TravelMemoryAggregatorTest.kt
+++ b/src/test/kotlin/com/example/travel/service/TravelMemoryAggregatorTest.kt
@@ -1,0 +1,128 @@
+package com.example.travel.service
+
+import com.example.travel.data.TravelHabits
+import com.example.travel.data.TravelHistory
+import com.example.travel.data.dao.TravelHabitsDao
+import com.example.travel.data.dao.TravelHistoryDao
+import java.time.Clock
+import java.time.Duration
+import java.time.Instant
+import java.time.ZoneOffset
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertTrue
+import kotlinx.coroutines.runBlocking
+
+class TravelMemoryAggregatorTest {
+
+    @Test
+    fun `aggregates eligible histories into workday morning habit`() = runBlocking {
+        val now = Instant.parse("2025-03-31T00:00:00Z")
+        val zone = ZoneOffset.UTC
+
+        val histories = listOf(
+            history(sessionId = 1, userId = 100, destination = "公司", reach = "2025-03-03T09:02:00Z"),
+            history(sessionId = 2, userId = 100, destination = "公司", reach = "2025-03-04T08:41:00Z"),
+            history(sessionId = 3, userId = 100, destination = "公司", reach = "2025-03-05T08:30:00Z"),
+            history(sessionId = 4, userId = 100, destination = "公司", reach = "2025-03-06T08:35:00Z"),
+            history(sessionId = 5, userId = 100, destination = "公司", reach = "2025-03-07T08:48:00Z")
+        )
+
+        val historyDao = InMemoryHistoryDao(histories.toMutableList())
+        val habitsDao = InMemoryHabitsDao()
+        val aggregator = TravelMemoryAggregator(
+            historyDao = historyDao,
+            habitsDao = habitsDao,
+            clock = Clock.fixed(now, zone),
+            zoneId = zone
+        )
+
+        val report = aggregator.aggregateLongTermMemories()
+
+        assertEquals(1, report.createdHabits.size)
+        val habit = habitsDao.inserted.single()
+        assertEquals("公司", habit.destination)
+        assertEquals("工作日", habit.travelTag)
+        assertEquals(1, historyDao.remainingHistories())
+        assertTrue(report.consumedSessionIds.containsAll(listOf(1L, 2L, 3L, 4L, 5L)))
+    }
+
+    @Test
+    fun `cleans up leftovers older than two cycles`() = runBlocking {
+        val now = Instant.parse("2025-04-30T00:00:00Z")
+        val zone = ZoneOffset.UTC
+        val staleCreateTime = now.minus(Duration.ofDays(35)).toEpochMilli()
+
+        val histories = mutableListOf(
+            TravelHistory(
+                sessionId = 10,
+                createTime = staleCreateTime,
+                userId = 200,
+                destination = "老家",
+                reachTime = staleCreateTime,
+                relationShip = ""
+            )
+        )
+
+        val historyDao = InMemoryHistoryDao(histories)
+        val habitsDao = InMemoryHabitsDao()
+        val aggregator = TravelMemoryAggregator(
+            historyDao = historyDao,
+            habitsDao = habitsDao,
+            clock = Clock.fixed(now, zone),
+            zoneId = zone
+        )
+
+        val report = aggregator.aggregateLongTermMemories()
+
+        assertTrue(report.createdHabits.isEmpty())
+        assertEquals(0, historyDao.remainingHistories())
+        assertEquals(1, report.staleHistoryDeleted)
+    }
+
+    private fun history(
+        sessionId: Long,
+        userId: Long,
+        destination: String,
+        reach: String
+    ): TravelHistory {
+        val reachInstant = Instant.parse(reach)
+        val createTime = reachInstant.minus(Duration.ofDays(1)).toEpochMilli()
+        return TravelHistory(
+            sessionId = sessionId,
+            createTime = createTime,
+            userId = userId,
+            destination = destination,
+            reachTime = reachInstant.toEpochMilli(),
+            relationShip = "同事"
+        )
+    }
+
+    private class InMemoryHistoryDao(
+        private val histories: MutableList<TravelHistory>
+    ) : TravelHistoryDao {
+
+        override suspend fun loadHistoriesBefore(cutoffEpochMs: Long): List<TravelHistory> =
+            histories.filter { it.createTime <= cutoffEpochMs }
+
+        override suspend fun deleteBySessionIds(sessionIds: Collection<Long>) {
+            histories.removeAll { it.sessionId in sessionIds.toSet() }
+        }
+
+        override suspend fun deleteOlderThan(cutoffEpochMs: Long): Int {
+            val before = histories.size
+            histories.removeAll { it.createTime < cutoffEpochMs }
+            return before - histories.size
+        }
+
+        fun remainingHistories(): Int = histories.size
+    }
+
+    private class InMemoryHabitsDao : TravelHabitsDao {
+        val inserted = mutableListOf<TravelHabits>()
+
+        override suspend fun insertHabits(habits: Collection<TravelHabits>) {
+            inserted += habits
+        }
+    }
+}


### PR DESCRIPTION
Implement `TravelMemoryAggregator` to summarize historical trips into long-term habits and manage history record lifecycle.

This fulfills the product requirement to automatically generate user travel habits from their trip history, including rules for grouping by user/destination, normalizing arrival times, summarizing weekdays, and purging old records.

---
<a href="https://cursor.com/background-agent?bcId=bc-4ca9f22a-e50b-44d6-9aac-6c6af6f2e573"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-4ca9f22a-e50b-44d6-9aac-6c6af6f2e573"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

