### PR TITLE
Debounce segment merge bug

### DIFF
--- a/src/Demo.kt
+++ b/src/Demo.kt
@@ -1,0 +1,30 @@
+private fun assertEquals(expected: Any?, actual: Any?, message: String = "") {
+    if (expected != actual) {
+        val prefix = if (message.isBlank()) "" else "$message: "
+        throw IllegalStateException(prefix + "expected=$expected, actual=$actual")
+    }
+}
+
+fun main() {
+    // 你的例子：空字符串应当被当作“其它”(负例)并丢弃，不应该进入结果 key
+    val seq1 = listOf("人-踹车", "人-踹踹踹踹") + List(80) { "" }
+    val r1 = mergeSegmentsWithDebounce(seq1)
+    assertEquals(setOf("人-踹车", "人-踹踹踹踹"), r1.keys.toSet(), "seq1 keys")
+    check("" !in r1.keys) { "empty label should not be included" }
+
+    // 单个负例窗口不应打断连续性；但负例本身也不能出现在输出
+    val seq2 = listOf("A", "", "B")
+    val r2 = mergeSegmentsWithDebounce(seq2)
+    assertEquals(listOf(1), r2["A"], "seq2 A positions")
+    assertEquals(listOf(3), r2["B"], "seq2 B positions")
+    check("" !in r2.keys) { "empty label should not be included" }
+
+    // “其它”同样作为负例处理
+    val seq3 = listOf("其它", "A", "其它", "其它", "B")
+    val r3 = mergeSegmentsWithDebounce(seq3)
+    assertEquals(listOf(2), r3["A"], "seq3 A positions")
+    assertEquals(listOf(5), r3["B"], "seq3 B positions")
+
+    println("OK")
+}
+

--- a/src/MergeSegmentsWithDebounce.kt
+++ b/src/MergeSegmentsWithDebounce.kt
@@ -1,0 +1,122 @@
+/**
+ * 哨兵各窗口推理结果合并
+ *
+ * 对预测序列应用防抖动和防截断逻辑
+ *
+ * BUGFIX:
+ * - 将 "" / 空白字符串 视为“其它”(负例)处理：不会参与分段、计票与最终输出。
+ */
+fun mergeSegmentsWithDebounce(
+    predSequence: List<String>,
+    gapThreshold: Int = 1
+): LinkedHashMap<String, List<Int>> {
+    @Suppress("UNUSED_PARAMETER")
+    val _gapThreshold = gapThreshold // 保留接口兼容性
+
+    val negativeLabels = setOf("X", "其它")
+    fun isNegativeLabel(label: String): Boolean = label.isBlank() || label in negativeLabels
+
+    val continuousSegments = mutableListOf<IntRange>()
+    var i = 0
+
+    while (i < predSequence.size) {
+        if (isNegativeLabel(predSequence[i])) {
+            var j = i
+            var negCount = 0
+            while (j < predSequence.size && isNegativeLabel(predSequence[j])) {
+                negCount++
+                j++
+            }
+            i = if (negCount >= 2) j else i + 1
+            continue
+        }
+
+        val start = i
+        var end = i
+        var j = i + 1
+
+        while (j < predSequence.size) {
+            if (isNegativeLabel(predSequence[j])) {
+                var k = j
+                var negCount = 0
+                while (k < predSequence.size && isNegativeLabel(predSequence[k])) {
+                    negCount++
+                    k++
+                }
+                if (negCount >= 2) {
+                    end = j - 1
+                    break
+                }
+                if (k < predSequence.size) {
+                    j = k
+                    end = k
+                    continue
+                } else {
+                    end = predSequence.lastIndex
+                    j = k
+                    break
+                }
+            } else {
+                end = j
+                j++
+            }
+        }
+
+        if (j >= predSequence.size) {
+            end = predSequence.lastIndex
+        }
+        continuousSegments.add(start..end)
+        i = end + 1
+    }
+
+    val finalActionsWithPositions = LinkedHashMap<String, MutableList<Int>>()
+
+    continuousSegments.forEach { range ->
+        val segment = predSequence.subList(range.first, range.last + 1)
+        val actionCount = mutableMapOf<String, Int>()
+        val actionHasContinuous = mutableSetOf<String>()
+
+        segment.forEachIndexed { idxInSegment, label ->
+            if (!isNegativeLabel(label)) {
+                actionCount[label] = actionCount.getOrDefault(label, 0) + 1
+                if (idxInSegment < segment.lastIndex && segment[idxInSegment + 1] == label) {
+                    actionHasContinuous.add(label)
+                }
+            }
+        }
+
+        if (actionCount.isEmpty()) return@forEach
+
+        val selectedLabels = linkedSetOf<String>()
+        fun selectLabels(predicate: (String) -> Boolean) {
+            for (absIdx in range) {
+                val label = predSequence[absIdx]
+                if (!isNegativeLabel(label) && predicate(label)) {
+                    selectedLabels.add(label)
+                }
+            }
+        }
+
+        val allEqual = actionCount.values.distinct().size == 1
+        if (allEqual) {
+            selectLabels { true }
+        } else {
+            val maxCount = actionCount.values.max() ?: return@forEach
+            selectLabels { it in actionHasContinuous }
+            selectLabels { actionCount[it] == maxCount }
+        }
+
+        for (absIdx in range) {
+            val label = predSequence[absIdx]
+            if (label in selectedLabels) {
+                finalActionsWithPositions
+                    .getOrPut(label) { mutableListOf() }
+                    .add(absIdx + 1) // store 1-based index
+            }
+        }
+    }
+
+    return finalActionsWithPositions
+        .mapValuesTo(LinkedHashMap()) { it.value.toList() }
+}
+


### PR DESCRIPTION
Fix `mergeSegmentsWithDebounce` to treat empty/blank strings as negative labels, ensuring they are discarded and do not appear in the merged results.

Previously, empty or blank strings were not explicitly handled as negative labels, leading to them potentially being counted or selected in the merging process and appearing as keys in the final output. This change unifies the negative label check to include `isBlank()`, preventing such labels from affecting the merge logic or output.

---
<a href="https://cursor.com/background-agent?bcId=bc-1110630f-fa9c-40cf-b1fe-9456516d7655"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-1110630f-fa9c-40cf-b1fe-9456516d7655"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

