### PR TITLE
Top command log improvements

### DIFF
--- a/top_log.sh
+++ b/top_log.sh
@@ -2,20 +2,20 @@
 set -euo pipefail
 
 # Collect top snapshots every second and write to a log file.
+# Runs until Ctrl+C is pressed.
 # Usage: ./top_log.sh [output_file]
 
-SAMPLES=100
 INTERVAL=1
 
 timestamp="$(date +%Y%m%d_%H%M%S)"
 log_file="${1:-top100_${timestamp}.log}"
 
 echo "=== Log start: $(date '+%F %T') ===" >> "$log_file"
-for ((i=1; i<=SAMPLES; i++)); do
+trap 'echo "=== Log complete: $(date "+%F %T") ===" >> "$log_file"; exit 0' INT
+
+while true; do
   echo "=== Time: $(date '+%F %T') ===" >> "$log_file"
   top -b -n 1 >> "$log_file"
-  if (( i < SAMPLES )); then
-    sleep "$INTERVAL"
-  fi
+  echo "" >> "$log_file"
+  sleep "$INTERVAL"
 done
-echo "=== Log complete: $(date '+%F %T') ===" >> "$log_file"

--- a/top_log.sh
+++ b/top_log.sh
@@ -5,7 +5,8 @@ set -euo pipefail
 # Runs until Ctrl+C is pressed.
 # Usage: ./top_log.sh [output_file]
 
-INTERVAL=0.5
+INTERVAL_SECONDS=1
+INTERVAL_NS=$((INTERVAL_SECONDS * 1000000000))
 
 timestamp="$(date +%Y%m%d_%H%M%S)"
 log_file="${1:-top100_${timestamp}.log}"
@@ -14,8 +15,16 @@ echo "=== Log start: $(date '+%F %T') ===" >> "$log_file"
 trap 'echo "=== Log complete: $(date "+%F %T") ===" >> "$log_file"; exit 0' INT
 
 while true; do
+  loop_start_ns="$(date +%s%N)"
   echo "=== Time: $(date '+%F %T') ===" >> "$log_file"
   top -b -n 1 >> "$log_file"
   echo "" >> "$log_file"
-  sleep "$INTERVAL"
+
+  loop_end_ns="$(date +%s%N)"
+  elapsed_ns=$((loop_end_ns - loop_start_ns))
+  if (( elapsed_ns < INTERVAL_NS )); then
+    remaining_ns=$((INTERVAL_NS - elapsed_ns))
+    sleep "$(printf '%d.%09d' $((remaining_ns / 1000000000)) \
+      $((remaining_ns % 1000000000)))"
+  fi
 done

--- a/top_log.sh
+++ b/top_log.sh
@@ -22,9 +22,13 @@ while true; do
 
   loop_end_ns="$(date +%s%N)"
   elapsed_ns=$((loop_end_ns - loop_start_ns))
-  if (( elapsed_ns < INTERVAL_NS )); then
-    remaining_ns=$((INTERVAL_NS - elapsed_ns))
-    sleep "$(printf '%d.%09d' $((remaining_ns / 1000000000)) \
-      $((remaining_ns % 1000000000)))"
+  if (( elapsed_ns < 0 )); then
+    elapsed_ns=0
+  fi
+  remaining_ns=$((INTERVAL_NS - elapsed_ns))
+  if (( remaining_ns > 0 )); then
+    seconds=$((remaining_ns / 1000000000))
+    nanos=$((remaining_ns % 1000000000))
+    sleep "$(printf '%d.%09d' "$seconds" "$nanos")"
   fi
 done

--- a/top_log.sh
+++ b/top_log.sh
@@ -1,0 +1,21 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+# Collect top snapshots every second and write to a log file.
+# Usage: ./top_log.sh [output_file]
+
+SAMPLES=100
+INTERVAL=1
+
+timestamp="$(date +%Y%m%d_%H%M%S)"
+log_file="${1:-top100_${timestamp}.log}"
+
+echo "=== Log start: $(date '+%F %T') ===" >> "$log_file"
+for ((i=1; i<=SAMPLES; i++)); do
+  echo "=== Time: $(date '+%F %T') ===" >> "$log_file"
+  top -b -n 1 >> "$log_file"
+  if (( i < SAMPLES )); then
+    sleep "$INTERVAL"
+  fi
+done
+echo "=== Log complete: $(date '+%F %T') ===" >> "$log_file"

--- a/top_log.sh
+++ b/top_log.sh
@@ -5,7 +5,7 @@ set -euo pipefail
 # Runs until Ctrl+C is pressed.
 # Usage: ./top_log.sh [output_file]
 
-INTERVAL=1
+INTERVAL=0.5
 
 timestamp="$(date +%Y%m%d_%H%M%S)"
 log_file="${1:-top100_${timestamp}.log}"


### PR DESCRIPTION
Add `top_log.sh` to capture `top` output with timestamps to a user-specified or default timestamped log file.

---
<a href="https://cursor.com/background-agent?bcId=bc-b1f51b27-9caa-4fe6-b194-a94f18b55cfd"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-b1f51b27-9caa-4fe6-b194-a94f18b55cfd"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

