### PR TITLE
Sentry output folder name

### DIFF
--- a/SentryOutDirName.kt
+++ b/SentryOutDirName.kt
@@ -1,0 +1,27 @@
+/**
+ * Get sentry output directory name.
+ *
+ * @return output directory name
+ */
+fun getSentryOutDirName(videoPath: String): String {
+    return if (config().extractUseFileName) {
+        val fileName = extractFileName(videoPath)
+        if (fileName.isBlank()) {
+            System.nanoTime().toString()
+        } else {
+            fileName.substringBeforeLast('.', fileName)
+        }
+    } else {
+        System.nanoTime().toString()
+    }
+}
+
+private fun extractFileName(videoPath: String): String {
+    val trimmedPath = videoPath.trim()
+    if (trimmedPath.isEmpty()) {
+        return ""
+    }
+    val withoutFragment = trimmedPath.substringBefore('#')
+    val withoutQuery = withoutFragment.substringBefore('?')
+    return withoutQuery.substringAfterLast('/', withoutQuery)
+}


### PR DESCRIPTION
Add `getSentryOutDirName` to generate sentry output directory names based on configuration, either from the video filename (without extension) or a timestamp.

---
<a href="https://cursor.com/background-agent?bcId=bc-73db9376-2c84-40b0-a6f6-f90ff8683470"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-73db9376-2c84-40b0-a6f6-f90ff8683470"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

