### PR TITLE
Sentry output directory cleanup

### DIFF
--- a/SentryOutputDirectory.kt
+++ b/SentryOutputDirectory.kt
@@ -1,0 +1,31 @@
+import java.io.File
+
+fun prepareSentryOutputDir(outputParentDir: File, videoPath: String): File {
+    val destDir = File(outputParentDir, getSentryOutDirName(videoPath))
+
+    if (destDir.exists()) {
+        destDir.deleteRecursively()
+    }
+
+    if (!destDir.exists()) {
+        destDir.mkdirs()
+    }
+
+    return destDir
+}
+
+fun getSentryOutDirName(videoPath: String): String {
+    val trimmedPath = videoPath.trim()
+    if (trimmedPath.isEmpty()) {
+        return System.nanoTime().toString()
+    }
+
+    val withoutFragment = trimmedPath.substringBefore('#')
+    val withoutQuery = withoutFragment.substringBefore('?')
+    val fileName = withoutQuery.substringAfterLast('/', withoutQuery)
+    if (fileName.isBlank()) {
+        return System.nanoTime().toString()
+    }
+
+    return fileName.substringBeforeLast('.', fileName)
+}

--- a/VideoPosition.kt
+++ b/VideoPosition.kt
@@ -1,0 +1,33 @@
+const val VIDEO_POSITION_FRONT_UP = 1
+const val VIDEO_POSITION_FRONT = 0
+const val VIDEO_POSITION_RIGHT = 2
+const val VIDEO_POSITION_BACK = 3
+const val VIDEO_POSITION_LEFT = 4
+
+fun getVideoPosition(videoPath: String): Int {
+    if (videoPath.isBlank()) return VIDEO_POSITION_FRONT
+
+    val lastSegment = try {
+        android.net.Uri.parse(videoPath).lastPathSegment
+    } catch (_: Exception) {
+        null
+    }
+
+    val fileName = (lastSegment ?: videoPath.substringAfterLast('/'))
+        .substringBefore('?')
+        .substringBefore('#')
+
+    val baseName = fileName.substringBeforeLast('.', fileName)
+    val suffix = baseName
+        .substringAfterLast('_', missingDelimiterValue = "")
+        .uppercase()
+
+    return when (suffix) {
+        "FA" -> VIDEO_POSITION_FRONT_UP
+        "FR" -> VIDEO_POSITION_FRONT
+        "RI" -> VIDEO_POSITION_RIGHT
+        "RE" -> VIDEO_POSITION_BACK
+        "LE" -> VIDEO_POSITION_LEFT
+        else -> VIDEO_POSITION_FRONT
+    }
+}


### PR DESCRIPTION
Add `prepareSentryOutputDir` to delete existing output directories before recreation, preventing outdated data from affecting results.

---
<a href="https://cursor.com/background-agent?bcId=bc-e9f0fbef-a99a-48ed-afd9-720086be6acc"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-e9f0fbef-a99a-48ed-afd9-720086be6acc"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

