### PR TITLE
feat: EDC 部署脚本支持自动 adb connect

### DIFF
--- a/scripts/edc_aibox_deploy.sh
+++ b/scripts/edc_aibox_deploy.sh
@@ -1,0 +1,75 @@
+#!/usr/bin/env bash
+# EDC + AIBOX 环境部署入口：在检测到设备未连接时自动执行 adb connect。
+set -euo pipefail
+
+EDC_IP="${EDC_IP:-172.16.6.50}"
+EDC_PORT="${EDC_PORT:-5555}"
+EDC_ADDR="${EDC_IP}:${EDC_PORT}"
+ADB_CONNECT_RETRIES="${ADB_CONNECT_RETRIES:-3}"
+ADB_CONNECT_SLEEP_SEC="${ADB_CONNECT_SLEEP_SEC:-2}"
+
+edc_state() {
+  # 输出该地址在 adb devices 中的第二列状态：device / offline / unauthorized / 空（未列出）
+  adb devices 2>/dev/null | awk -v a="$EDC_ADDR" '$1==a {print $2; exit}'
+}
+
+edc_is_ready() {
+  [[ "$(edc_state)" == "device" ]]
+}
+
+try_adb_connect() {
+  local attempt out
+  for ((attempt = 1; attempt <= ADB_CONNECT_RETRIES; attempt++)); do
+    echo "  --> 尝试 adb 连接 (${attempt}/${ADB_CONNECT_RETRIES}): adb connect ${EDC_ADDR}"
+    set +e
+    out="$(adb connect "${EDC_ADDR}" 2>&1)"
+    code=$?
+    set -e
+    echo "      ${out}"
+    if edc_is_ready; then
+      return 0
+    fi
+    sleep "${ADB_CONNECT_SLEEP_SEC}"
+  done
+  return 1
+}
+
+echo "=============================================="
+echo "  EDC + AIBOX 环境部署"
+echo "=============================================="
+echo ""
+
+adb start-server >/dev/null 2>&1 || true
+
+echo "  --> 当前 adb 设备列表："
+adb devices
+echo ""
+
+if edc_is_ready; then
+  echo "  [√] 已检测到 EDC（${EDC_ADDR}），状态为 device。"
+else
+  state="$(edc_state)"
+  if [[ -n "${state}" ]]; then
+    echo "  [!] EDC（${EDC_ADDR}）当前状态为「${state}」，将尝试重新连接…"
+  else
+    echo "  [x] 未检测到 EDC（${EDC_IP}）。正在自动执行: adb connect ${EDC_ADDR}"
+  fi
+
+  if ! try_adb_connect; then
+    echo ""
+    echo "  [x] 自动连接失败。请检查："
+    echo "      - 设备已开启 USB/无线调试，且端口 ${EDC_PORT} 可达"
+    echo "      - 本机与 ${EDC_IP} 网络互通"
+    echo "      - 可手动执行: adb connect ${EDC_ADDR}"
+    exit 1
+  fi
+
+  echo ""
+  echo "  --> 连接后的 adb 设备列表："
+  adb devices
+  echo ""
+  echo "  [√] 已自动连接 EDC（${EDC_ADDR}）。"
+fi
+
+echo ""
+echo "  （在此脚本末尾追加你的部署步骤，或 source 本脚本后继续使用 adb。）"


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## 变更说明

仓库原先仅有 `.gitignore`，本次新增 `scripts/edc_aibox_deploy.sh`：在「EDC + AIBOX 环境部署」流程中，若 `adb devices` 未将 `EDC_IP:EDC_PORT`（默认 `172.16.6.50:5555`）列为 `device`，则自动执行 `adb connect` 并重试（默认 3 次，间隔 2 秒），成功后再继续后续部署步骤占位。

## 可配置环境变量

- `EDC_IP`（默认 `172.16.6.50`）
- `EDC_PORT`（默认 `5555`）
- `ADB_CONNECT_RETRIES`、`ADB_CONNECT_SLEEP_SEC`

## 使用方式

在项目根目录执行：`bash scripts/edc_aibox_deploy.sh`，或将本仓库克隆到本地工作目录后在该目录下执行。
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-34c7792d-77f8-460b-bb50-7be889a98bf7"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-34c7792d-77f8-460b-bb50-7be889a98bf7"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

